### PR TITLE
SHA256 checksum added to validate the download

### DIFF
--- a/linux-eoip/Makefile
+++ b/linux-eoip/Makefile
@@ -13,7 +13,7 @@ PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=http://github.com/bogdik/openwrt-linux-eoip/releases/download/0.6/
-PKG_MD5SUM:=d3e11bfd3fdc6a9eeec62c3c5afcf734
+PKG_HASH:=22f6f3864665adef26c7fbd57543a396108ba2dff1282af8143f18bc2a9912f8
 
 PKG_INSTALL:=1
 


### PR DESCRIPTION
PKG_MD5SUM replaced with SHA256 checksum.

https://github.com/openwrt/packages/pull/14334#discussion_r549484808_